### PR TITLE
refactor(home): change ‘version’ text to ‘sprint’

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: website/default
 
 <p class="ws-todo-bar">Contact <a class="temp-dark-bg" href="mailto:helix.designsystem@rackspace.com?subject=Collaboration Request">helix.designsystem@rackspace.com</a> to contribute or request additional components.</p>
 
-<h1 class="ws-section-head">Version 0.2</h1>
+<h1 class="ws-section-head">Sprint 2</h1>
 <h3>Target Release Date: September 7, 2016</h3>
 <p class="ws-upcoming-desc">Google analytics will be added.</p>
 <p class="ws-list-label">Components:</p>
@@ -19,7 +19,7 @@ layout: website/default
   <li class="ws-li">Date Picker</li>
 </ol>
 
-<h1 class="ws-section-head">Version 0.3</h1>
+<h1 class="ws-section-head">Sprint 3</h1>
 <h3>Target Release Date: September 30, 2016</h3>
 <p class="ws-upcoming-desc">This release will implement a more thought-out taxonomy, better focus states on form components, and improved keyboard accessibility.</p>
 <p class="ws-list-label">Components:</p>


### PR DESCRIPTION
Removes usage of the word "Version" on the home page and uses "Sprint" instead.