### PR TITLE
refactor(header): fixes broken path to rackspace logo

### DIFF
--- a/_includes/website/header.html
+++ b/_includes/website/header.html
@@ -1,5 +1,5 @@
 <header class="site-header">
-    <div class="logo"><img src="{{site.baseurl}}{{site.websiteAssets}}img/rs-logo.svg" class="logo"></div>
+    <div class="logo"><img src="{{site.baseurl}}assets/img/rs-logo.svg" class="logo"></div>
     <div class="nameplate"><span>Helix</span>&nbsp;Design System</div>
 </header>
 <nav>


### PR DESCRIPTION
I got automated deployments working, and also noticed that the header logo path was incorrect.  It looks like all the images, etc were moved out of the folders for website and design-system.

Checking in a change that will fix the missing header logo, and watching the awesomeness of automated deployment.