### PR TITLE
[m] updating gitignore to hide in-the-meantime staging deploy solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ vendor
 old/
 
 .remarkrc
+
+tar_staging.sh
+package.tgz
+
+design-system


### PR DESCRIPTION
Set up a quick script locally for making the deploy to staging easier until Travis is running. 