### PR TITLE
Preview icons usage/evan

### DIFF
--- a/_component_design/actions-menu.md
+++ b/_component_design/actions-menu.md
@@ -4,7 +4,8 @@ parent: Editing
 secondary: Inputs and Controls
 layout: component
 category: Components
-usage: null
+usage: >
+  The actions menu is used anytime a group of actions can be performed on a specific object on the current page or the current page. By grouping these actions within the actions menu, it allows users to have a single location to trigger multiple types of actions.
 preview-image: components/preview-help.svg
 status: unknown
 resource: false

--- a/_component_design/alert-bar.md
+++ b/_component_design/alert-bar.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   A notification bar extends fully across the top of an content container within a Helix interface in order to provide the user with feedback relating to the status of the item. It can be scoped across the entirity of the content area (page level scoping) or scoped to extend across a singular section of the content area (element level scoping).
-preview-image: components/preview-help.svg
+preview-image: preview-images/alert-bar.svg
 status: deprecated, in-progress
 resource: true
 last-modified: 2017-08-17

--- a/_component_design/alert-bar.md
+++ b/_component_design/alert-bar.md
@@ -3,12 +3,8 @@ title: Alert Bar
 parent: Notifications
 layout: component
 category: Components
-usage: |
- Use notification bars for information that will remain static unless
- changed by a user. For example, you could use notification bars for
- Info messages about a new feature available to a user, or an Error
- message informing the user that their credit card was unable to be
- processed this month.
+usage: >
+  A notification bar extends fully across the top of an content container within a Helix interface in order to provide the user with feedback relating to the status of the item. It can be scoped across the entirity of the content area (page level scoping) or scoped to extend across a singular section of the content area (element level scoping).
 preview-image: components/preview-help.svg
 status: deprecated, in-progress
 resource: true

--- a/_component_design/application-navigation.md
+++ b/_component_design/application-navigation.md
@@ -3,7 +3,8 @@ title: Application navigation
 parent: Navigation
 layout: component
 category: Components
-usage: Application navigation establishes the user's path.
+usage: > 
+  Application navigation establishes a user's location within an application and shows the path forward to accomplish a goal. Consistent navigation patterns increase user confidence and efficiency.
 preview-image: layout/preview-images/navigation.svg
 resource: true
 ---

--- a/_component_design/application-navigation.md
+++ b/_component_design/application-navigation.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: > 
   Application navigation establishes a user's location within an application and shows the path forward to accomplish a goal. Consistent navigation patterns increase user confidence and efficiency.
-preview-image: layout/preview-images/navigation.svg
+preview-image: preview-images/app-nav.svg
 resource: true
 ---
 

--- a/_component_design/breadcrumbs.md
+++ b/_component_design/breadcrumbs.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Breadcrumbs are an inline visual representation of page relationships and hierarchy. They provide a user with visual reinforcement of the current location within the application hierarchy, and allow for quick movement up the hierarchy.
-preview-image: components/placeholder.svg
+preview-image: preview-images/breadcrumbs.svg
 status: deprecated
 resource: true
 ---

--- a/_component_design/breadcrumbs.md
+++ b/_component_design/breadcrumbs.md
@@ -3,8 +3,8 @@ title: Breadcrumbs
 parent: Navigations
 layout: component
 category: Components
-usage: |
-  Use breadcrumbs on Rackspace subpages to let the user know where they are in the heirarchy, and to allow them to jump up the heirarchy if they need to.
+usage: >
+  Breadcrumbs are an inline visual representation of page relationships and hierarchy. They provide a user with visual reinforcement of the current location within the application hierarchy, and allow for quick movement up the hierarchy.
 preview-image: components/placeholder.svg
 status: deprecated
 resource: true

--- a/_component_design/bucket-selector.md
+++ b/_component_design/bucket-selector.md
@@ -3,7 +3,8 @@ title: Bucket Selector
 parent: Selector
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  Bucket Selector is helpful when you are selecting multiple objects from large option sets within a larger workflow. The bucket area (located below the table) operates as a holding area where users can view all their selections, regardless of the table content. This allows users to search and/or filter the table to locate items to select without losing visibility into what they have selected.
 preview-image: components/device-picker.svg
 published: true
 status: complete, in-progress

--- a/_component_design/buttons.md
+++ b/_component_design/buttons.md
@@ -4,8 +4,8 @@ parent: Editing
 secondary: Inputs and Controls
 layout: component
 category: Components
-usage: |
-  Use primary, secondary and tertiary button types to signal important actions.
+usage: >
+  Buttons direct user attention to important actions that can be performed from the current page. Varies types of buttons are used based on the importance of each action.
 preview-image: components/preview-selectors.svg
 status: pending
 resource: true

--- a/_component_design/buttons.md
+++ b/_component_design/buttons.md
@@ -5,7 +5,7 @@ secondary: Inputs and Controls
 layout: component
 category: Components
 usage: >
-  Buttons direct user attention to important actions that can be performed from the current page. Varies types of buttons are used based on the importance of each action.
+  Buttons direct user attention to important actions that can be performed from the current page. Base the use of various types of buttons on the importance of each action.
 preview-image: preview-images/buttons.svg
 status: pending
 resource: true

--- a/_component_design/buttons.md
+++ b/_component_design/buttons.md
@@ -6,7 +6,7 @@ layout: component
 category: Components
 usage: >
   Buttons direct user attention to important actions that can be performed from the current page. Varies types of buttons are used based on the importance of each action.
-preview-image: components/preview-selectors.svg
+preview-image: preview-images/buttons.svg
 status: pending
 resource: true
 last-modified: 2017-08-17

--- a/_component_design/charts.md
+++ b/_component_design/charts.md
@@ -4,7 +4,7 @@ parent: Data Visualizations
 layout: component
 category: Components
 usage: Teaser Text
-preview-image: components/preview-help.svg
+preview-image: preview-images/charts.svg
 resource: true
 status: in-progress
 need: charts

--- a/_component_design/checkboxes.md
+++ b/_component_design/checkboxes.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Checkboxes are used to change settings or bulk item selection. Checkboxes allow the user to select zero, one or several items.
-preview-image: components/preview-selectors.svg
+preview-image: preview-images/checkboxes.svg
 resource: true
 status: in-progress
 need: selectors

--- a/_component_design/checkboxes.md
+++ b/_component_design/checkboxes.md
@@ -3,9 +3,8 @@ title: Checkboxes
 parent: Inputs and Controls
 layout: component
 category: Components
-usage: |
-  Helix controls allow users to select options in a variety of ways including
-  radio buttons, checkboxes, switches and more.
+usage: >
+  Checkboxes are used to change settings or bulk item selection. Checkboxes allow the user to select zero, one or several items.
 preview-image: components/preview-selectors.svg
 resource: true
 status: in-progress

--- a/_component_design/checkboxes.md
+++ b/_component_design/checkboxes.md
@@ -4,7 +4,7 @@ parent: Inputs and Controls
 layout: component
 category: Components
 usage: >
-  Checkboxes are used to change settings or bulk item selection. Checkboxes allow the user to select zero, one or several items.
+  Checkboxes are used to change settings or bulk item selection. Checkboxes allow the user to select zero, one, or several items.
 preview-image: preview-images/checkboxes.svg
 resource: true
 status: in-progress

--- a/_component_design/chips.md
+++ b/_component_design/chips.md
@@ -3,8 +3,9 @@ title: Chips
 parent: Content Areas
 layout: component
 category: Components
-usage: Teaser Text
-preview-image: components/chips.svg
+usage: >
+  Chips represent distinct filters or chunks of metadata that apply to the currently viewed component. Chips provide the user with the visual understading of these chunks as well as the ability to interact with them. Examples of this pattern included displaying tags and search terms.
+preview-image: preview-images/chip.svg
 resource: true
 status: in-progress
 last-modified: 2017-08-17

--- a/_component_design/chips.md
+++ b/_component_design/chips.md
@@ -4,7 +4,7 @@ parent: Content Areas
 layout: component
 category: Components
 usage: >
-  Chips represent distinct filters or chunks of metadata that apply to the currently viewed component. Chips provide the user with the visual understading of these chunks as well as the ability to interact with them. Examples of this pattern included displaying tags and search terms.
+  Chips represent a conceptual unit, such as a user, a device, a filter term, or a chunk of metadata and provide the user with the visual understanding of this conceptual unit as well as the ability to interact with them.
 preview-image: preview-images/chip.svg
 resource: true
 status: in-progress

--- a/_component_design/cog.md
+++ b/_component_design/cog.md
@@ -4,7 +4,8 @@ parent: Editing
 secondary: Inputs and Controls
 layout: component
 category: Components
-usage: null
+usage: >
+  The cog is an icon from the Helix icon set that is widely used across Helix applications. These cogs allow users to interact with and perform actions on a component or page.
 preview-image: components/preview-help.svg
 status: unknown
 resource: false

--- a/_component_design/content-dividers.md
+++ b/_component_design/content-dividers.md
@@ -3,7 +3,8 @@ title: Content Dividers
 parent: null
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  Content dividers are used within content areas to generate visual seperation. This seperation help to increase user understanding by segmenting information into distinct groups.
 preview-image:
 status: unknown
 resource: false

--- a/_component_design/content-dividers.md
+++ b/_component_design/content-dividers.md
@@ -4,7 +4,7 @@ parent: null
 layout: component
 category: Components
 usage: >
-  Content dividers are used within content areas to generate visual seperation. This seperation help to increase user understanding by segmenting information into distinct groups.
+  Content dividers are used within content areas to generate visual seperation. This seperation helps to increase user understanding by segmenting information into distinct groups.
 preview-image:
 status: unknown
 resource: false

--- a/_component_design/date-pickers.md
+++ b/_component_design/date-pickers.md
@@ -3,7 +3,8 @@ title: Date Pickers
 parent: Inputs and Controls
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  Date picker allows users to select a date or a range of dates in the process of filling out a search field or input form.
 preview-image: components/date-picker.svg
 status: unknown
 resource: true

--- a/_component_design/date-pickers.md
+++ b/_component_design/date-pickers.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Date picker allows users to select a date or a range of dates in the process of filling out a search field or input form.
-preview-image: components/date-picker.svg
+preview-image: preview-images/date-picker.svg
 status: unknown
 resource: true
 last-modified: 2017-08-17

--- a/_component_design/dropdowns.md
+++ b/_component_design/dropdowns.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Dropdowns are one of the core input mechanisms for selecting options on a form. Dropdowns are used to provide a user with options or actions that effect the output of the form as a whole.
-preview-image: components/preview-selectors.svg
+preview-image: preview-images/drop-downs.svg
 resource: true
 status: in-progress
 need: selectors

--- a/_component_design/dropdowns.md
+++ b/_component_design/dropdowns.md
@@ -3,8 +3,9 @@ title: Drop-downs
 parent: Inputs and Controls
 layout: component
 category: Components
-usage: Drop-downs are a core input mechanism for forms and are used to offer selection from multiple options or actions.
-preview-image: components/content-areas/dropdowns/dropdowns-hero.svg
+usage: >
+  Dropdowns are one of the core input mechanisms for selecting options on a form. Dropdowns are used to provide a user with options or actions that effect the output of the form as a whole.
+preview-image: components/preview-selectors.svg
 resource: true
 status: in-progress
 need: selectors

--- a/_component_design/growl.md
+++ b/_component_design/growl.md
@@ -3,9 +3,8 @@ title: Growl
 parent: Notifications
 layout: component
 category: Components
-usage: |
-  These tooltips provide users with additional information while completing
-  tasks and alert them to new features.
+usage: >
+  These tooltips provide users with additional information while completing tasks and alert them to new features.
 preview-image: components/growl-placement.svg
 status: deprecated, in-progress
 resource: false

--- a/_component_design/help-beacon.md
+++ b/_component_design/help-beacon.md
@@ -5,11 +5,11 @@ secondary: Notifications
 layout: component
 category: Components
 usage: >
-  The Beacon can be used to identify the location of products or features in the control panel. It can also be used to indicate advanced functionality to existing features
+  The beacon can be used to identify the location of products or features in the control panel. It can also be used to indicate advanced functionality to existing features
 preview-image: preview-images/help-beacon.svg
 status: in-progress
 resource: true
-last-modified: 2017-10-04
+last-modified: 2017-08-17
 ---
 
 {% include toc.html %}

--- a/_component_design/help-beacon.md
+++ b/_component_design/help-beacon.md
@@ -4,13 +4,12 @@ parent: Help
 secondary: Notifications
 layout: component
 category: Components
-usage: |
-  These tooltips provide users with additional information while completing
-  tasks and alert them to new features.
-preview-image: components/preview-help.svg
-status: deprecated, in-progress
+usage: >
+  The Beacon can be used to identify the location of products or features in the control panel. It can also be used to indicate advanced functionality to existing features
+preview-image: preview-images/help-beacon.svg
+status: in-progress
 resource: true
-last-modified: 2017-08-17
+last-modified: 2017-10-04
 ---
 
 {% include toc.html %}

--- a/_component_design/help-link.md
+++ b/_component_design/help-link.md
@@ -6,8 +6,8 @@ category: Components
 usage: |
   These tooltips provide users with additional information while completing
   tasks and alert them to new features.
-preview-image: components/preview-help.svg
-status: unknown, in-progress
+preview-image: preview-images/help-link.svg
+status: in-progress
 resource: true
 last-modified: 2017-08-17
 ---

--- a/_component_design/horizontal-stepper.md
+++ b/_component_design/horizontal-stepper.md
@@ -3,8 +3,9 @@ title: Horizontal Stepper
 parent: Content Areas
 layout: component
 category: Components
-usage: Teaser Text
-preview-image: components/stepper-horizontal-2.svg
+usage: >
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et purus nec dui scelerisque viverra non at enim. Maecenas consequat nisi in rhoncus molestie. 
+preview-image: preview-images/horizontal-stepper.svg
 resource: true
 status: in-progress
 last-modified: 2017-08-17

--- a/_component_design/key-value-pairs.md
+++ b/_component_design/key-value-pairs.md
@@ -3,7 +3,10 @@ title: Key Value Pairs
 parent: unknown
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  Key value pairs are used to display data with their corresponding label. Color
+  and alignment are used to enhance readability allowing users to quickly scan
+  for the page for relevant data.
 preview-image: null
 resource: true
 status: unknown

--- a/_component_design/loading.md
+++ b/_component_design/loading.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Loading indicators help to reassure the user that the system is actively retrieving data.
-preview-image: components/loading-linear.svg
+preview-image: preview-images/loading.svg
 resource: true
 status: unknown
 last-modified: 2017-08-17

--- a/_component_design/loading.md
+++ b/_component_design/loading.md
@@ -3,7 +3,8 @@ title: Loading
 parent: Processing
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  Loading indicators help to reassure the user that the system is actively retrieving data.
 preview-image: components/loading-linear.svg
 resource: true
 status: unknown

--- a/_component_design/modals.md
+++ b/_component_design/modals.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Modals are a content area that pops up in the middle of the users display with the page content behind it obscured. Modals are commonly used to command user attention or to force a user decision. Modals are best used when important or potentially destructive operations are occurring.
-preview-image:
+preview-image: preview-images/modal.svg
 resource: true
 status: unknown
 last-modified: 2017-08-17

--- a/_component_design/modals.md
+++ b/_component_design/modals.md
@@ -3,9 +3,10 @@ title: Modals
 parent: Content Areas
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  Modals are a content area that pops up in the middle of the users display with the page content behind it obscured. Modals are commonly used to command user attention or to force a user decision. Modals are best used when important or potentially destructive operations are occurring.
 preview-image:
-resource: false
+resource: true
 status: unknown
 last-modified: 2017-08-17
 ---

--- a/_component_design/popovers.md
+++ b/_component_design/popovers.md
@@ -4,9 +4,10 @@ parent: Content Areas
 secondary: Editing
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  A popover is a small group of information or inputs that is presented in a panel that is overlayed on top of the original page, preserving the user’s context.
 preview-image: components/preview-images/popover.svg
-resouce: false
+resource: true
 status: unknown
 last-modified: 2017-08-17
 ---

--- a/_component_design/popovers.md
+++ b/_component_design/popovers.md
@@ -6,7 +6,7 @@ layout: component
 category: Components
 usage: >
   A popover is a small group of information or inputs that is presented in a panel that is overlayed on top of the original page, preserving the user’s context.
-preview-image: components/preview-images/popover.svg
+preview-image: preview-images/popover.svg
 resource: true
 status: unknown
 last-modified: 2017-08-17

--- a/_component_design/radio-buttons.md
+++ b/_component_design/radio-buttons.md
@@ -3,9 +3,8 @@ title: Radio Buttons
 parent: Inputs and Controls
 layout: component
 category: Components
-usage: |
-  Helix controls allow users to select options in a variety of ways including
-  radio buttons, checkboxes, switches and more.
+usage: >
+  Radio buttons are used when the user is only allowed to select one option from a list. A minimum of one choice is required, and one is preselected by default.
 preview-image: components/preview-selectors.svg
 resource: true
 status: in-progress

--- a/_component_design/radio-buttons.md
+++ b/_component_design/radio-buttons.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Radio buttons are used when the user is only allowed to select one option from a list. A minimum of one choice is required, and one is preselected by default.
-preview-image: components/preview-selectors.svg
+preview-image: preview-images/radio-buttons.svg
 resource: true
 status: in-progress
 need: selectors

--- a/_component_design/sliders.md
+++ b/_component_design/sliders.md
@@ -6,7 +6,7 @@ category: Components
 usage: |
   Helix controls allow users to select options in a variety of ways including
   radio buttons, checkboxes, switches and more.
-preview-image: components/preview-selectors.svg
+preview-image: preview-images/sliders.svg
 resource: true
 status: in-progress
 need: selectors

--- a/_component_design/switches.md
+++ b/_component_design/switches.md
@@ -3,9 +3,8 @@ title: Switches
 parent: null
 layout: component
 category: Components
-usage: |
-  Helix controls allow users to select options in a variety of ways including
-  radio buttons, checkboxes, switches and more.
+usage: >
+  A switch is used for a binary decision; and only for the purpose of yes/no or on/off. They are especially useful when building mobile based designs.
 preview-image: components/preview-selectors.svg
 resource: true
 need: selectors

--- a/_component_design/tables-old.md
+++ b/_component_design/tables-old.md
@@ -3,7 +3,8 @@ title: Tables (old)
 parent: Tables
 layout: component
 category: Components
-usage: Teaser Text
+usage: >
+  Tables present data on nearly every page in Helix control panels. Tables are highly valuable, but always run the risk of putting too high a cognitive load on users. Our goal with tables should always be to decrease cognitive load so users can get the data they need quickly and easily.
 preview-image: components/preview-images/tables.svg
 resource: true
 last-modified: 2017-08-17

--- a/_component_design/tables-old.md
+++ b/_component_design/tables-old.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Tables present data on nearly every page in Helix control panels. Tables are highly valuable, but always run the risk of putting too high a cognitive load on users. Our goal with tables should always be to decrease cognitive load so users can get the data they need quickly and easily.
-preview-image: components/preview-images/tables.svg
+preview-image: preview-images/tables.svg
 resource: true
 last-modified: 2017-08-17
 ---

--- a/_component_design/tabset.md
+++ b/_component_design/tabset.md
@@ -3,8 +3,9 @@ title: Tabset
 parent: Content Areas
 layout: component
 category: Components
-usage: Tabsets separate content into different views, making it easy to explore content by clicking a descriptive tab title. Switching between tabs is quick, since it doesn't require scrolling or refreshing the page. Tabs enable content organization at a high level, such as switching between views, data sets, or functional aspects of an application.
-preview-image: components/preview-images/tabs.svg
+usage: >
+  Tabs provide users with the ability to access multiple sections of content seperated by tabs. This seperation makes it easy to explore and switch between different views. Tabs enable content organization at a high level, such as switching between views, data sets, or functional aspects of an app.
+preview-image: preview-images/tabs.svg
 resource: true
 status: unknown
 last-modified: 2017-09-11

--- a/_component_design/text-inputs.md
+++ b/_component_design/text-inputs.md
@@ -5,7 +5,7 @@ layout: component
 category: Components
 usage: >
   Text fields typically reside in forms but can appear in other places, like dialog boxes and search. Text fields validate input, help users fix errors, autocomplete words, and provide suggestions.
-preview-image: components/preview-fields.svg
+preview-image: preview-images/text-inputs.svg
 resource: true
 status: unknown
 last-modified: 2017-08-17

--- a/_component_design/text-inputs.md
+++ b/_component_design/text-inputs.md
@@ -3,9 +3,8 @@ title: Text Inputs
 parent: Inputs and Controls
 layout: component
 category: Components
-usage: |
-  Helix provides a variety of text inputs to allow users to enter information
-  into a page.
+usage: >
+  Text fields typically reside in forms but can appear in other places, like dialog boxes and search. Text fields validate input, help users fix errors, autocomplete words, and provide suggestions.
 preview-image: components/preview-fields.svg
 resource: true
 status: unknown

--- a/_component_design/time-pickers.md
+++ b/_component_design/time-pickers.md
@@ -4,7 +4,7 @@ parent: Inputs and Controls
 layout: component
 category: Components
 usage: Teaser Text
-preview-image: components/time-picker.svg
+preview-image: preview-images/time-picker.svg
 resource: true
 last-modified: 2017-08-17
 ---

--- a/_component_design/toast.md
+++ b/_component_design/toast.md
@@ -3,9 +3,8 @@ title: Toast
 parent: Notifications
 layout: component
 category: Components
-usage: |
-  These tooltips provide users with additional information while completing
-  tasks and alert them to new features.
+usage: >
+  Toasts are a specialized notification component used to provide feedback on the status of an actions taking place in the background. Toasts are meant to be ephemeral and capture users attention by having the highest Z-index of all components.
 preview-image: components/preview-images/toast.svg
 status: deprecated
 resource: false

--- a/_component_design/toggles.md
+++ b/_component_design/toggles.md
@@ -6,7 +6,7 @@ category: Components
 usage: |
   Helix controls allow users to select options in a variety of ways including
   radio buttons, checkboxes, switches and more.
-preview-image: components/preview-selectors.svg
+preview-image: preview-images/toggles.svg
 resource: true
 need: selectors
 status: in-progress

--- a/_component_design/tooltip.md
+++ b/_component_design/tooltip.md
@@ -3,10 +3,9 @@ title: Tooltip
 parent: Help
 layout: component
 category: Components
-usage: |
-  These tooltips provide users with additional information while completing
-  tasks and alert them to new features.
-preview-image: components/preview-help.svg
+usage: >
+  Use the tooltip when you want to convey brief snippets of information, to explain an element a bit more, or to display truncated text.
+preview-image: preview-images/tooltip.svg
 status: unknown
 resource: true
 last-modified: 2017-08-17

--- a/_component_design/vertical-stepper.md
+++ b/_component_design/vertical-stepper.md
@@ -3,8 +3,9 @@ title: Vertical Stepper
 parent: Content Areas
 layout: component
 category: Components
-usage: Teaser Text
-preview-image: components/stepper-2.svg
+usage: >
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et purus nec dui scelerisque viverra non at enim. Maecenas consequat nisi in rhoncus molestie. 
+preview-image: preview-images/vertical-stepper.svg
 resource: true
 status: in-progress
 last-modified: 2017-08-17

--- a/assets/css/_sass/website/_component-page.scss
+++ b/assets/css/_sass/website/_component-page.scss
@@ -45,6 +45,7 @@
   .component-blurb {
     font-size: $font-size-3;
     color: $grey900;
+    line-height: $font-size-5;
   }
   .hero-image {
     margin: 36px auto 44px auto;

--- a/assets/css/_sass/website/_component-page.scss
+++ b/assets/css/_sass/website/_component-page.scss
@@ -45,7 +45,7 @@
   .component-blurb {
     font-size: $font-size-3;
     color: $grey900;
-    line-height: $font-size-5;
+    line-height: $base-line-height;
   }
   .hero-image {
     margin: 36px auto 44px auto;

--- a/assets/css/_sass/website/_docs-page.scss
+++ b/assets/css/_sass/website/_docs-page.scss
@@ -30,7 +30,7 @@
   font-weight: $light-weight;
   margin: 0px 0px;
   text-align: left !important;
-  line-height: $font-size-5;
+  line-height: $base-line-height;
 }
 .component-row-status {
   font-size: $font-size-3;

--- a/assets/css/_sass/website/_docs-page.scss
+++ b/assets/css/_sass/website/_docs-page.scss
@@ -28,8 +28,9 @@
   font-size: $base-font-size;
   color: $grey900;
   font-weight: $light-weight;
-  margin: 16px 0px;
+  margin: 0px 0px;
   text-align: left !important;
+  line-height: $font-size-5;
 }
 .component-row-status {
   font-size: $font-size-3;

--- a/assets/css/_sass/website/_home.scss
+++ b/assets/css/_sass/website/_home.scss
@@ -64,6 +64,7 @@
 }
 
 .overview-content {
+  padding: 0px 0px !important;
   p {
     font-size: $base-font-size !important;
     font-weight: $light-weight;

--- a/assets/css/_sass/website/_layout.scss
+++ b/assets/css/_sass/website/_layout.scss
@@ -181,7 +181,7 @@ video {
   max-width: 100%;
 }
 
-figure {
+figure:not(figcaption) {
   margin: 0 0 8px 0;
 }
 
@@ -191,6 +191,7 @@ figcaption {
   margin: 0;
   line-height: $base-line-height;
   font-weight: $light-weight;
+  margin: 0 0 8px 0;
 }
 
 p {

--- a/assets/css/_sass/website/_layout.scss
+++ b/assets/css/_sass/website/_layout.scss
@@ -51,6 +51,7 @@ nav.side {
     box-sizing: border-box;
     overflowY: scroll;
     flex: 1;
+    padding: 0px 0px !important;
   }
 };
 

--- a/templates/_includes/nav.html
+++ b/templates/_includes/nav.html
@@ -1,7 +1,7 @@
 <nav class="hxApp__nav side">
   <div class="logo"><a href="{{site.url}}/"><img src="{{site.cdn_url}}/img/helix_logo_nav.svg" class="logo" class="logo"></a></div>
   {% assign currenturl = page.url %}
-  <a href="{{site.url}}/" {% if currenturl == "/" %} class="current" {% else %} {% endif %}>Home</a>
+  <a href="{{site.url}}/" {% if currenturl == "/" %} class="current" {% else %} {% endif %}>HOME</a>
   {% for navItem in site.data.navigation %}
     {% assign currentNav = navItem.name | slugify %}
     {% if currentNav != "components" %}


### PR DESCRIPTION
This PR performs small tweaks on the styling for family pages, specifically on the blurbs that appears on them as well as in the header of the component page. It also provides two new major features that take advantage of these style changes.

- Usage YAML information was updated across all files that are currently marked as resource: true
- Thumbnail icons were created in the style that Ty dictated and stored on a CDN, then preview-image YAML information was updated across all files that are currently marked as resource: true.