### PR TITLE
Thumbnail update/evan

### DIFF
--- a/_component_design/footer.md
+++ b/_component_design/footer.md
@@ -8,31 +8,24 @@ usage: |
   globally applicable, but non-primary navigation information. Use it on
   every page and every wrapped application. For customer applications,
   it should not exceed the articulated scope.
-preview-image: components/preview-images/popover.svg
+preview-image: preview-images/footer-thumbnail.svg
 resource: true
 status: in-progress
 last-modified: 2017-10-03
 ---
 
-# Footer
+### Introduction
 
 <div class="hxRow">
+
 {% column left:"hxCol-4 hxCol-xs-12 hxCol-sm-12 hxCol-md-4 hxCol-lg-4" %}
-The footer lives at the bottom of the page to help visitors find global, 
-secondary navigation information. We recommend using it on every page
-and every wrapped application. For customer applications, it should
-not exceed the articulated scope.
 
-{% figure [caption:"Thumbnail."] [class:"image bg-light border"] %}
-  ![]({{site.url}}/assets/images/components/content-areas/footer/footer-thumbnail.svg){:width="80%"}
-{% endfigure %}
-
-## When to use footers
+#### When to use footers
 
 Use the Rackspace footer on every application page to provide consistent
 global functionality on all of our platforms.
 
-## Best practices for footers
+#### Best practices for footers
 
 Place the footer at the bottom of every page. If the page uses left-hand
 navigation, ensure the footer is to the right of the screen, and spans the
@@ -44,19 +37,27 @@ the bottom of the entire page. Ensure the footer contains the following:
 * A link to the privacy policy
 
 {% endcolumn %}
+
+{% column right:"hxCol-8 hxCol-xs-12 hxCol-sm-12 hxCol-md-8 hxCol-lg-8" %}
+
+{% figure [caption:"Thumbnail."] [class:"image bg-light border"] %}
+  ![]({{site.url}}/assets/images/components/content-areas/footer/footer-thumbnail.svg){:width="80%"}
+{% endfigure %}
+
+{% endcolumn %}
 </div>
 
-# Specifications
+### Specifications
 <div class="hxRow">
 {% column left:"hxCol-4 hxCol-xs-12 hxCol-sm-12 hxCol-md-4 hxCol-lg-4" %}
 
-## Footer scope
+#### Footer scope
 
 The footer must contain copyright information with links to Rackspace
 website terms and privacy policy.
 
-* Website Terms: https://www.rackspace.com/information/legal/websiteterms
-* Privacy Policy: https://www.rackspace.com/information/legal/privacystatement
+* <a href="https://www.rackspace.com/information/legal/websiteterms" target="_blank">Website Terms</a> 
+* <a href="https://www.rackspace.com/information/legal/privacystatement" target="_blank">Privacy Policy</a>
 
 For customer applications, do not add additional functionality to the footer.
 {% endcolumn %}
@@ -68,7 +69,7 @@ For customer applications, do not add additional functionality to the footer.
 {% endcolumn %}
 </div>
 
-## Footer specifications
+### Footer specifications
 <div class="hxRow">
 {% column left:"hxCol-4 hxCol-xs-12 hxCol-sm-12 hxCol-md-4 hxCol-lg-4" %}
 
@@ -80,7 +81,7 @@ the Links documentation.
 
 {% column right:"hxCol-8 hxCol-xs-12 hxCol-sm-12 hxCol-md-8 hxCol-lg-8" %}
 {% figure [caption:"Default image"] [class:"image bg-light border"] %}
- ![]({{site.url}}/assets/images/components/content-areas/footer/footer-spec.svg){:width="80%"}
+ ![]({{site.url}}/assets/images/components/content-areas/footer/footer-specs.svg){:width="80%"}
 {% endfigure %}
 {% endcolumn %}
 </div>

--- a/assets/css/_sass/website/_component-page.scss
+++ b/assets/css/_sass/website/_component-page.scss
@@ -1,5 +1,9 @@
 // New design
 .component-content {
+  h3 {
+    margin-top: 0;
+    margin-bottom: 1em;
+  }
   h4 {
     margin-top: 0;
     margin-bottom: 1rem;

--- a/assets/images/components/content-areas/footer/footer-thumbnail.svg
+++ b/assets/images/components/content-areas/footer/footer-thumbnail.svg
@@ -2,18 +2,16 @@
 <svg width="293px" height="195px" viewBox="0 0 293 195" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 47 (45396) - http://www.bohemiancoding.com/sketch -->
     <title>footer-thumbnail</title>
-    <desc>Created with Sketch.</desc>
+    <desc>Stylized thumbnail for footer component in the Helix design language.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="footer-thumbnail">
-            <g id="vertical-stepper-copy">
-                <g id="application-frame">
-                    <rect id="Rectangle" fill="#B6E3EB" x="0" y="0" width="293" height="195"></rect>
-                    <rect id="Rectangle-Copy" fill="#16B9D4" x="0" y="0" width="48.8333333" height="195"></rect>
-                    <rect id="Rectangle-Copy-2" fill="#0E94A6" x="0" y="0" width="293" height="14.625"></rect>
-                </g>
+            <g id="application-frame">
+                <rect id="Rectangle" fill="#B6E3EB" x="0" y="0" width="293" height="195"></rect>
+                <rect id="Rectangle-2" fill="#16B9D4" x="0" y="0" width="48.8333333" height="195"></rect>
+                <rect id="Rectangle-3" fill="#0E94A6" x="0" y="0" width="293" height="14.625"></rect>
             </g>
-            <rect id="Rectangle-3" fill="#F57C00" fill-rule="nonzero" x="0" y="186" width="293" height="9"></rect>
+            <rect id="Rectangle-4" fill="#F57C00" fill-rule="nonzero" x="0" y="186" width="293" height="9"></rect>
         </g>
     </g>
 </svg>

--- a/assets/images/components/content-areas/footer/footer-thumbnail.svg
+++ b/assets/images/components/content-areas/footer/footer-thumbnail.svg
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="293px" height="195px" viewBox="0 0 293 195" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <!-- Generator: Sketch 47 (45396) - http://www.bohemiancoding.com/sketch -->
     <title>footer-thumbnail</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Stylized-components-" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="footer-thumbnail">
             <g id="vertical-stepper-copy">
                 <g id="application-frame">
-                    <rect id="Rectangle" fill="#B6E3EB" fill-rule="evenodd" x="0" y="0" width="293" height="195"></rect>
-                    <rect id="Rectangle-Copy" fill="#16B9D4" fill-rule="evenodd" x="0" y="0" width="48.8333333" height="195"></rect>
-                    <rect id="Rectangle-Copy-2" fill="#0E94A6" fill-rule="evenodd" x="0" y="0" width="293" height="14.625"></rect>
-                    <g id="overlay-/-hidden"></g>
+                    <rect id="Rectangle" fill="#B6E3EB" x="0" y="0" width="293" height="195"></rect>
+                    <rect id="Rectangle-Copy" fill="#16B9D4" x="0" y="0" width="48.8333333" height="195"></rect>
+                    <rect id="Rectangle-Copy-2" fill="#0E94A6" x="0" y="0" width="293" height="14.625"></rect>
                 </g>
             </g>
-            <rect id="Rectangle-3" fill="#F57C00" x="49" y="186" width="244" height="9"></rect>
+            <rect id="Rectangle-3" fill="#F57C00" fill-rule="nonzero" x="0" y="186" width="293" height="9"></rect>
         </g>
     </g>
 </svg>


### PR DESCRIPTION
This PR fixes the items noted in the following image from PR 283.
https://user-images.githubusercontent.com/933210/31347430-fadbc5dc-ace1-
11e7-9b92-e0622c4609ad.png.  Additionally a 1rem bottom-margin was
added to H3 elements that are wrapped inside the `component-content`
div elements so this change is scoped to only Component page content. Headings used in the `.md` file were updated to be H3 and H4 respectively in lue of H1 and H2. Finally the preview SVG metadata itself was scrubbed to be a little cleaner.