### PR TITLE
fix(revert-h3-margins): Reverting spacing on h3

### DIFF
--- a/_component_design/footer.md
+++ b/_component_design/footer.md
@@ -15,7 +15,7 @@ last-modified: 2017-10-03
 ---
 
 ### Introduction
-
+{: .hxSectionTitle}
 <div class="hxRow">
 
 {% column left:"hxCol-4 hxCol-xs-12 hxCol-sm-12 hxCol-md-4 hxCol-lg-4" %}
@@ -48,6 +48,7 @@ the bottom of the entire page. Ensure the footer contains the following:
 </div>
 
 ### Specifications
+{: .hxSectionTitle}
 <div class="hxRow">
 {% column left:"hxCol-4 hxCol-xs-12 hxCol-sm-12 hxCol-md-4 hxCol-lg-4" %}
 
@@ -70,6 +71,7 @@ For customer applications, do not add additional functionality to the footer.
 </div>
 
 ### Footer specifications
+{: .hxSectionTitle}
 <div class="hxRow">
 {% column left:"hxCol-4 hxCol-xs-12 hxCol-sm-12 hxCol-md-4 hxCol-lg-4" %}
 

--- a/assets/css/_sass/website/_component-page.scss
+++ b/assets/css/_sass/website/_component-page.scss
@@ -1,9 +1,5 @@
 // New design
 .component-content {
-  h3 {
-    margin-top: 0;
-    margin-bottom: 1em;
-  }
   h4 {
     margin-top: 0;
     margin-bottom: 1rem;


### PR DESCRIPTION
This went in as part of PR-290 and a better means to accomplish this
has been found by Laura.

———

Evan Nabors [9:56 AM]
Does that ^ mean I should revert the 1rem margin-bottom on h3's in the
footer PR and use this process instead?

[9:56]
https://github.com/rackerlabs/design-system/pull/290/files#diff-1709761f
33d26e33b1c43086716758f5 (edited)

[9:56]
change in question

Laura Santamaria [9:57 AM]
excellent! and @evan.nabors, yeah, probably. That way, we don’t have to
worry about it long-term should the design get adjusted