### PR TITLE
bug(bucket): rehide bucket-selector doc

### DIFF
--- a/_component_design/bucket-selector.md
+++ b/_component_design/bucket-selector.md
@@ -8,7 +8,7 @@ usage: >
 preview-image: components/device-picker.svg
 published: true
 status: in-progress
-resource: true
+resource: false
 last-modified: 2017-08-17
 ---
 


### PR DESCRIPTION
Closes issue - https://github.com/rackerlabs/design-system/issues/345

bucket-selector was unhidden, this rehides it. easy peasy.