### PR TITLE
Make left nav sticky

### DIFF
--- a/assets/css/_sass/website/_home.scss
+++ b/assets/css/_sass/website/_home.scss
@@ -46,6 +46,7 @@
     text-align: center;
     overflowY: scroll;
     flex: 1;
+    margin-left: 15rem;
 };
   background-image: url(../images/Helix_Homepage_Pattern.svg);
   background-color: $grey25;

--- a/assets/css/_sass/website/_layout.scss
+++ b/assets/css/_sass/website/_layout.scss
@@ -17,10 +17,11 @@ body {
 }
 
 nav.side {
-    display: flex;
-    flex-direction: column;
-    flex-shrink: 0;
-    min-height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    overflow-y: auto;
     .logo {
         display: block;
         // height: 98px;
@@ -52,6 +53,7 @@ nav.side {
     overflowY: scroll;
     flex: 1;
     padding: 0px 0px !important;
+    margin-left: 15rem;
   }
 };
 


### PR DESCRIPTION
Makes left nav sticky via position: fixed.
Updates the overview content and component content css to have the correct left offset.