### PR TITLE
Populate landing page links

### DIFF
--- a/assets/css/_sass/website/_home.scss
+++ b/assets/css/_sass/website/_home.scss
@@ -111,6 +111,11 @@
       bottom: 0px;
       left: 0;
       right: 0;
+      .card-button {
+        a {
+          color: $grey0;
+        }
+      }
     }
     p {
       font-weight: $regular-weight;

--- a/assets/css/_sass/website/_home.scss
+++ b/assets/css/_sass/website/_home.scss
@@ -90,7 +90,7 @@
     position: relative;
     border: 1px solid $grey400;
     margin: 32px auto 40px auto;
-    padding: 0px 10px;
+    padding: 20px;
     min-height: 23.57rem;
     width: 14.25rem;
     text-align: center;
@@ -104,13 +104,14 @@
       font-weight: 600;
       font-size: $base-font-size;
       color: $grey900;
-      margin: 0px auto;
+      margin: 20px auto;
     }
     .card-bottom {
       position: absolute;
       bottom: 0px;
       left: 0;
       right: 0;
+      margin: 20px auto;
       .card-button {
         a {
           color: $grey0;
@@ -135,6 +136,7 @@
       li {
         line-height: $base-line-height !important;
         text-align: center;
+        padding: 0.25rem 0;
       };
     }
     .card-button {

--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ customers happy.
     </ul>
     <div class="card-bottom">
       <div class="card-button">
-        <button class="hxBtn hxBtn--primary"><a href="{{site.baseurl}}getting-started/design.html">Full Designer Guide</a></button>
+        <a class="hxBtn hxBtn--primary" href="{{site.baseurl}}getting-started/design.html">Full Designer Guide</a>
       </div>
     </div>
   </div>
@@ -28,13 +28,13 @@ customers happy.
     <span class="card-heading">For Developers</span>
     <p>Use these resources to learn and implement Helix patterns.</p>
     <ul>
-      <li><a href="#">Pattern Guidelines</a></li>
-      <li><a href="#">UI Framework</a></li>
-      <li><a href="#">Component Explorer</a></li>
+      <li><a href="http://helix.rax.io/">Pattern Guidelines</a></li>
+      <li><a href="https://rackerlabs.github.io/helix-ui/">UI Framework</a></li>
+      <li><a href="https://rackerlabs.github.io/helix-ui/">Component Explorer</a></li>
     </ul>
     <div class="card-bottom">
       <div class="card-button">
-        <button class="hxBtn hxBtn--primary"><a href="https://rackerlabs.github.io/helix-ui/guides/install/">Full Developer Guide</a></button>
+        <a href="https://rackerlabs.github.io/helix-ui/guides/install/" class="hxBtn hxBtn--primary">Full Developer Guide</a>
       </div>
     </div>
   </div>

--- a/index.md
+++ b/index.md
@@ -15,9 +15,9 @@ customers happy.
     <p>Start designing with Helix components.</p>
     <div class="card-bottom">
       <ul>
-        <li><a href="http://helix.rax.io/">Pattern Guidelines</a></li>
+        <li><a href="{{site.url}}">Pattern Guidelines</a></li>
         <li><a href="https://github.com/rackerlabs/helix/">Sketch Resources</a></li>
-        <li><a href="https://rackerlabs.github.io/helix-ui/" target="_blank">Component Explorer</a></li>
+        <li><a href="{{site.url}}/getting-started/design.html">Quick Start Guide</a></li>
       </ul>
     </div>
   </div>
@@ -27,7 +27,7 @@ customers happy.
     <p>Use these resources to implement Helix code.</p>
     <div class="card-bottom">
       <ul>
-        <li><a href="http://helix.rax.io/">Pattern Guidelines</a></li>
+        <li><a href="https://github.com/rackerlabs/helix-ui/">Code Repository</a></li>
         <li><a href="https://rackerlabs.github.io/helix-ui/guides/install/" target="_blank">Installation Guide</a></li>
         <li><a href="https://rackerlabs.github.io/helix-ui/" target="_blank">Component Explorer</a></li>
       </ul>

--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ customers happy.
     </ul>
     <div class="card-bottom">
       <div class="card-button">
-        <a class="hxBtn hxBtn--primary" href="{{site.baseurl}}getting-started/design.html">Full Designer Guide</a>
+        <a class="hxBtn hxBtn--primary" href="{{site.baseurl}}getting-started/design.html">View Designer Guide</a>
       </div>
     </div>
   </div>
@@ -34,7 +34,7 @@ customers happy.
     </ul>
     <div class="card-bottom">
       <div class="card-button">
-        <a href="https://rackerlabs.github.io/helix-ui/guides/install/" class="hxBtn hxBtn--primary">Full Developer Guide</a>
+        <a href="https://rackerlabs.github.io/helix-ui/guides/install/" class="hxBtn hxBtn--primary">Explore Developer Guide</a>
       </div>
     </div>
   </div>

--- a/index.md
+++ b/index.md
@@ -28,8 +28,8 @@ customers happy.
     <div class="card-bottom">
       <ul>
         <li><a href="https://github.com/rackerlabs/helix-ui/">Code Repository</a></li>
-        <li><a href="https://rackerlabs.github.io/helix-ui/guides/install/" target="_blank">Installation Guide</a></li>
-        <li><a href="https://rackerlabs.github.io/helix-ui/" target="_blank">Component Explorer</a></li>
+        <li><a href="https://rackerlabs.github.io/helix-ui/guides/install/" target="_blank">Installation Guide <hx-icon type="external-link"></hx-icon></a></li>
+        <li><a href="https://rackerlabs.github.io/helix-ui/" target="_blank">Component Explorer <hx-icon type="external-link"></hx-icon></a></li>
       </ul>
     </div>
   </div>

--- a/index.md
+++ b/index.md
@@ -12,30 +12,25 @@ customers happy.
   <div class="card" id="left">
     <div class="icon"><img src="assets/images/For_Designers_Icon.svg" alt="designer UX icon"/></div>
     <span class="card-heading">For Designers</span>
-    <p>Start making stuff with these tools now.</p>
-    <ul>
-      <li><a href="http://helix.rax.io/">Pattern Guidelines</a></li>
-      <li><a href="https://github.com/rackerlabs/helix">Sketch Resources</a></li>
-    </ul>
+    <p>Start designing with Helix components.</p>
     <div class="card-bottom">
-      <div class="card-button">
-        <a class="hxBtn hxBtn--primary" href="{{site.baseurl}}getting-started/design.html">View Designer Guide</a>
-      </div>
+      <ul>
+        <li><a href="http://helix.rax.io/">Pattern Guidelines</a></li>
+        <li><a href="https://github.com/rackerlabs/helix/">Sketch Resources</a></li>
+        <li><a href="https://rackerlabs.github.io/helix-ui/" target="_blank">Component Explorer</a></li>
+      </ul>
     </div>
   </div>
   <div class="card" id="right">
     <div class="icon"><img src="assets/images/For_Developers_Icon.svg" alt="developer code icon"/></div>
     <span class="card-heading">For Developers</span>
-    <p>Use these resources to learn and implement Helix patterns.</p>
-    <ul>
-      <li><a href="http://helix.rax.io/">Pattern Guidelines</a></li>
-      <li><a href="https://rackerlabs.github.io/helix-ui/">UI Framework</a></li>
-      <li><a href="https://rackerlabs.github.io/helix-ui/">Component Explorer</a></li>
-    </ul>
+    <p>Use these resources to implement Helix code.</p>
     <div class="card-bottom">
-      <div class="card-button">
-        <a href="https://rackerlabs.github.io/helix-ui/guides/install/" class="hxBtn hxBtn--primary">Explore Developer Guide</a>
-      </div>
+      <ul>
+        <li><a href="http://helix.rax.io/">Pattern Guidelines</a></li>
+        <li><a href="https://rackerlabs.github.io/helix-ui/guides/install/" target="_blank">Installation Guide</a></li>
+        <li><a href="https://rackerlabs.github.io/helix-ui/" target="_blank">Component Explorer</a></li>
+      </ul>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Had to use an anchor instead of the button for the link to work in FF :slightly_frowning_face:

fixes #357 