### PR TITLE
fix(logo): align with breadcrumbs

### DIFF
--- a/assets/css/_sass/website/_layout.scss
+++ b/assets/css/_sass/website/_layout.scss
@@ -23,7 +23,7 @@ nav.side {
     left: 0;
     bottom: 0;
     overflow-y: auto;
-    padding-top: 10px;
+    padding-top: 5px;
     a {
       font-weight: 400 !important;
     }

--- a/assets/css/_sass/website/_layout.scss
+++ b/assets/css/_sass/website/_layout.scss
@@ -23,6 +23,7 @@ nav.side {
     left: 0;
     bottom: 0;
     overflow-y: auto;
+    padding-top: 10px;
     a {
       font-weight: 400 !important;
     }


### PR DESCRIPTION
Tiny PR to address the following. As determined on Thursday, the adjustments to the eyebrow spacing resulted in the logo not aligning on the components pages as intended.

Before: 
![image](https://user-images.githubusercontent.com/586682/33849153-6477dd0e-de75-11e7-9a9e-a843ae768b6e.png)

After: 
![image](https://user-images.githubusercontent.com/586682/33849177-7a30a40a-de75-11e7-9292-e8863a816a4f.png)

