### PR TITLE
fix(bug): update install guide link for devs to helix toolkit getting started

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ customers happy.
     <div class="card-bottom">
       <ul>
         <li><a href="https://github.com/rackerlabs/helix-ui/">Code Repository <hx-icon type="external-link"></hx-icon></a></li>
-        <li><a href="https://rackerlabs.github.io/helix-ui/guides/install/" target="_blank">Installation Guide <hx-icon type="external-link"></hx-icon></a></li>
+        <li><a href="https://rackerlabs.github.io/helix-ui/guides/getting-started/" target="_blank">Installation Guide <hx-icon type="external-link"></hx-icon></a></li>
         <li><a href="https://rackerlabs.github.io/helix-ui/" target="_blank">Component Explorer <hx-icon type="external-link"></hx-icon></a></li>
       </ul>
     </div>


### PR DESCRIPTION
Updated the link under For Developers to the correct link to the helix-ui toolkit

![screen shot 2018-03-05 at 10 46 32 am](https://user-images.githubusercontent.com/10750223/36997571-abab3d46-207f-11e8-9cc3-7b98ef5d6bf4.png)
