### PR TITLE
fix(search): remove iOS styling for search inputs

### DIFF
--- a/assets/css/_sass/website/_search.scss
+++ b/assets/css/_sass/website/_search.scss
@@ -94,3 +94,11 @@
   font-size: $base-font-size;
   line-height: $base-line-height;
 }
+
+/* 
+ Prevent iOS from restyling search inputs
+*/
+
+input[type="search"] {
+  -webkit-appearance: none;
+}


### PR DESCRIPTION
Search input field in Safari wasn't taking our CSS due to iOS restyling; This removes this style and makes the search input look as intended.