### PR TITLE
update(docs): add low-fidelity sticker sheet

### DIFF
--- a/_docs/getting-started/design.md
+++ b/_docs/getting-started/design.md
@@ -69,12 +69,39 @@ Familiarize yourself with the concepts that define the Helix language. Through t
 
 ### Design mockups in Helix
 
-The best way to bring Helix components into your designs is with the Helix Sketch Sticker Sheet. You can copy and paste elements from this sticker sheet into your own Sketch documents to use in your designs.
+The best way to bring Helix components into your designs is with the Helix Sketch Sticker Sheet. You can copy and paste elements from this sticker sheet into your own Sketch documents to use in your designs. This resource is offered in both low and full fidelity variations.
 
-<a class="hxBtn hxBtn--primary" id="link" href="http://c1ee333499ed5f44e56a-fa12562cfe810d69bedcc36a0ac289ef.r55.cf1.rackcdn.com/sketch/helix_stickersheet_v0.1.sketch">Download Sticker Sheet</a>
+{% endcolumn %}
+
+</div>
+
+<div class="hxRow" markdown="1">
+
+{% column left:"hxCol-8 hxCol-xs-12 hxCol-sm-12 hxCol-md-8 hxCol-lg-8" %}
+
+#### Low fidelity
+
+We recommend using the low-fi version of the sticker sheet when creating the initial designs for a project. This allows stakeholders and designers to focus on the higher-level experience and without getting mired in the weeds of pixel-perfection.
+
+<a class="hxBtn" id="link" href="http://c1ee333499ed5f44e56a-fa12562cfe810d69bedcc36a0ac289ef.r55.cf1.rackcdn.com/sketch/low-fi_helix_stickersheet_v0.1.sketch">Download Low-fi Sticker Sheet</a>
+
+{% endcolumn %}
+
+</div>
+
+<div class="hxRow" markdown="1">
+
+{% column left:"hxCol-8 hxCol-xs-12 hxCol-sm-12 hxCol-md-8 hxCol-lg-8" %}
+
+#### Full fidelity
+
+Use the hi-fi sticker sheet once a design has been iterated and approved, and it’s time to start getting real clear about pixel-construction and behavior specifications.
+
+<a class="hxBtn" id="link" href="http://c1ee333499ed5f44e56a-fa12562cfe810d69bedcc36a0ac289ef.r55.cf1.rackcdn.com/sketch/helix_stickersheet_v0.1.sketch">Download Sticker Sheet</a>
 
 {% endcolumn %}
 
 </div>
 </section>
+
 

--- a/_docs/getting-started/design.md
+++ b/_docs/getting-started/design.md
@@ -67,7 +67,7 @@ Familiarize yourself with the concepts that define the Helix language. Through t
 
 {% column left:"hxCol-8 hxCol-xs-12 hxCol-sm-12 hxCol-md-8 hxCol-lg-8" %}
 
-### Design mockups in Helix
+### Sketch resources
 
 The best way to bring Helix components into your designs is with the Helix Sketch Sticker Sheet. You can copy and paste elements from this sticker sheet into your own Sketch documents to use in your designs. This resource is offered in both low and full fidelity variations.
 
@@ -81,7 +81,7 @@ The best way to bring Helix components into your designs is with the Helix Sketc
 
 #### Low fidelity
 
-We recommend using the low-fi version of the sticker sheet when creating the initial designs for a project. This allows stakeholders and designers to focus on the higher-level experience and without getting mired in the weeds of pixel-perfection.
+We recommend using the low-fi version of the sticker sheet when creating the initial designs for a project. This allows stakeholders and designers to focus on the higher-level experience without getting mired in the weeds of pixel-perfection.
 
 <a class="hxBtn" id="link" href="http://c1ee333499ed5f44e56a-fa12562cfe810d69bedcc36a0ac289ef.r55.cf1.rackcdn.com/sketch/low-fi_helix_stickersheet_v0.1.sketch">Download Low-fi Sticker Sheet</a>
 

--- a/_docs/getting-started/design.md
+++ b/_docs/getting-started/design.md
@@ -69,7 +69,7 @@ Familiarize yourself with the concepts that define the Helix language. Through t
 
 ### Sketch resources
 
-The best way to bring Helix components into your designs is with the Helix Sketch Sticker Sheet. You can copy and paste elements from this sticker sheet into your own Sketch documents to use in your designs. This resource is offered in both low and full fidelity variations.
+The best way to bring Helix components into your designs is with the Helix Sketch Sticker Sheet. You can copy and paste elements from this sticker sheet into your own Sketch documents to use in your designs. This resource is offered in both low and high fidelity variations.
 
 {% endcolumn %}
 
@@ -93,11 +93,11 @@ We recommend using the low-fi version of the sticker sheet when creating the ini
 
 {% column left:"hxCol-8 hxCol-xs-12 hxCol-sm-12 hxCol-md-8 hxCol-lg-8" %}
 
-#### Full fidelity
+#### High fidelity
 
-Use the hi-fi sticker sheet once a design has been iterated and approved, and it’s time to start getting real clear about pixel-construction and behavior specifications.
+Use the hi-fi sticker sheet once a design has been iterated and approved, and it’s time to start getting real clear about construction and behavior specifications.
 
-<a class="hxBtn" id="link" href="http://c1ee333499ed5f44e56a-fa12562cfe810d69bedcc36a0ac289ef.r55.cf1.rackcdn.com/sketch/helix_stickersheet_v0.1.sketch">Download Sticker Sheet</a>
+<a class="hxBtn" id="link" href="http://c1ee333499ed5f44e56a-fa12562cfe810d69bedcc36a0ac289ef.r55.cf1.rackcdn.com/sketch/helix_stickersheet_v0.1.sketch">Download Hi-fi Sticker Sheet</a>
 
 {% endcolumn %}
 

--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ customers happy.
     <div class="card-bottom">
       <ul>
         <li><a href="{{site.url}}/status.html">Pattern Guidelines</a></li>
-        <li><a href="{{site.cdn_url}}/sketch/helix_stickersheet_v0.1.sketch">Sketch Resources <hx-icon type="download"></hx-icon></a></li>
+        <li><a href="{{site.url}}/getting-started/design.html#sketch-resources">Sketch Resources </a></li>
         <li><a href="{{site.url}}/getting-started/design.html">Quick Start Guide</a></li>
       </ul>
     </div>


### PR DESCRIPTION
This PR adds the low-fi sticker sheet to the getting started for designers page. It is sourced from the RED rackspace cloud account via CDN. Any individual with permissions to that product / account

See attached screenshot for visuals or modified files.

![getting-started-designers](https://user-images.githubusercontent.com/586682/37537403-6aa36338-291b-11e8-8acb-ba8b266c67ba.png)

