### PR TITLE
bug(markdown): fixes capitalization problem on sketch-library.md

### DIFF
--- a/_docs/resources/sketch-library.md
+++ b/_docs/resources/sketch-library.md
@@ -27,8 +27,8 @@ usage: >
 {% column right:"hxCol hxSpan-12-xs hxSpan-12-sm hxSpan-8-md hxSpan-8-lg" %}
 
 <video controls loop autoplay>
-  {%comment%}<source src="{{site.url}}/assets/images/install-sketch-library/Install-library.mp4" type="video/mp4" codecs="avc1.42E01E, mp4a.40.2">{%endcomment%}
-  <source src="{{site.url}}/assets/images/install-sketch-library/Install-library.webm" type="video/webm" codecs="vp8, vorbis">
+  {%comment%}<source src="{{site.url}}/assets/images/install-sketch-library/Install-Library.mp4" type="video/mp4" codecs="avc1.42E01E, mp4a.40.2">{%endcomment%}
+  <source src="{{site.url}}/assets/images/install-sketch-library/Install-Library.webm" type="video/webm" codecs="vp8, vorbis">
   Your browser does not support HTML5 video.
 </video>
 


### PR DESCRIPTION
Noticed that the video didn't play on staging, but did play locally.  Realized that the name of the file is capitalized, but was not capitalized in the `src` attribute.  For some reason that difference makes it work locally, but not once it's deployed.

Fixed.