### PR TITLE
Tweak resources further

### DIFF
--- a/_docs/resources/index.md
+++ b/_docs/resources/index.md
@@ -16,10 +16,9 @@ category: Resources
   <div class="icon"><img src="{{site.baseurl}}/assets/images/sketch-library.svg" alt="sketch library icon"/>
     <h4>Sketch Library</h4>
   </div>
-    <p>The Sketch Library is the preferred method for creating high-fidelity design deliverables in the Helix language. It is installed directly via Sketch and brings high-fidelity Helix sketch objects into your sketch files.</p>
-    
-    <a class="hxBtn hxSecondary" href="{{site.cdn_url}}/sketch/helix-ui-components.sketch"><hx-icon type="download" style="margin-right:0.5rem;"></hx-icon> Download</a>
-    <a href="./sketch-library.html" style="margin-left: 0.75rem;" >How to Install</a>
+    <p>The Sketch Library is the preferred method for creating high-fidelity design deliverables. It is installed via Sketch and brings high-fidelity Helix elements into your files. Read <a href="./sketch-library.html" >How to Install the Sketch Library</a>.</p>
+    <a class="hxBtn hxSecondary" href="{{site.cdn_url}}/sketch/helix-ui-components.sketch"><hx-icon type="download" style="margin-right:0.5rem;"></hx-icon> Download Sketch Library</a>
+
 </div>
 
 {% endcolumn %}
@@ -30,8 +29,8 @@ category: Resources
   <div ><img src="{{site.baseurl}}/assets/images/lo-fi.svg" alt="low-fi icon"/>
     <h4>Low-fi Sticker sheet</h4>
   </div>
-    <p>We recommend using the low-fi sticker sheet to create initial designs for any project. This allows stakeholders and designers to focus on the higher-level experience without getting mired in the weeds of pixel-perfection.</p>
-    <a class="hxBtn hxSecondary" href="{{site.cdn_url}}/sketch/low-fi_helix_stickersheet_v0.1.sketch"><hx-icon type="download" style="margin-right:0.5rem;"></hx-icon> Download</a>
+    <p>We recommend using the low-fi sticker sheet to create initial designs for any project. This allows stakeholders and designers to focus on the higher-level experience without getting mired in pixel-perfection.</p>
+    <a class="hxBtn hxSecondary" href="{{site.cdn_url}}/sketch/low-fi_helix_stickersheet_v0.1.sketch"><hx-icon type="download" style="margin-right:0.5rem;"></hx-icon> Download Low-Fi Sticker Sheet</a>
 </div>
 
 {% endcolumn %}

--- a/_docs/resources/sketch-library.md
+++ b/_docs/resources/sketch-library.md
@@ -15,10 +15,16 @@ usage: >
 
 {% column left:"hxCol hxSpan-12-xs hxSpan-12-sm hxSpan-4-md hxSpan-4-lg" %}
 
+<a class="hxBtn hxSecondary" style="margin-left:2rem;" href="{{site.cdn_url}}/sketch/helix-ui-components.sketch"><hx-icon type="download" style="margin-right:0.5rem;"></hx-icon> Download Library</a>
+
 1. After you download the Sketch file, move it somewhere that you can remember, such as your desktop.
+
 2. Open Sketch and click **Sketch > Preferences**.
+
 3. On the **Preferences** dialog box, click **Libraries**, and then click **Add Library**.
+
 4. Go to **Desktop > helix-ui-components.sketch**.
+
 5. Click **Open**.
 
 

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -2,7 +2,7 @@
 layout: base2
 ---
 
-<div class="new-banner">
+<div class="fam-banner">
   <div class="content-wrapper">
     <h1>{{page.category | replace: '-', ' '}}</h1>
   </div>


### PR DESCRIPTION
Adds more descriptive text to the download buttons on the resources page
Adds more descriptive text to the link to the installation instructions link (duplicates article title)
changes header class on docs template so that the titles are in the same location on each page.